### PR TITLE
Allow unselect in single unit selection. 

### DIFF
--- a/ngSelect.js
+++ b/ngSelect.js
@@ -89,10 +89,6 @@ function NgSelectCtrl($scope) {
   };
 
   ctrl.unselect = function (optionObj) {
-    if (!_config.multiple) {
-      return;
-    }
-
     optionObj.selected = false;
 
     _updateModel();


### PR DESCRIPTION
Problem: once I selected an item I can't unselect it and have empty selection. 

If you need behavior similar to radio-button you can use select-disabled to disable selected element from choosing. E.g.:

``` html
<div ng-select-option="value" select-disabled="$optSelected"></div>
```
