### PR TITLE
ngSelectedOption $optDisabled rewritten to be precalculated as others

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ Type: `expression`
 Default: `undefined`
 
 Disables the interactivity of options if the expression is evaluated to be `true`. The evaluation has the access to the additional local scope with `$optIndex`, `$optValue`, `$optSelected` varaibles to increase the usage flexibility. This optional directive is applicable to `ng-select` as global configuration and also applicable to `ng-select-option` as local configuration.
-`select-disabled` expression can't use `$optDisabled` for obvious recursion reasons.
 
 [Live Example](http://pc035860.github.io/ngSelect/example/#/select-disabled)
 ```html

--- a/ngSelect.js
+++ b/ngSelect.js
@@ -36,7 +36,8 @@ function NgSelectCtrl($scope) {
     var optionObj = {
       index: _optionIndex++,
       value: value,
-      selected: false
+      selected: false,
+      disabled: false
     };
 
     if (_config.multiple) {
@@ -261,7 +262,7 @@ function NgSelectCtrl($scope) {
 
             // bind click event
             iElm.bind('click', function () {
-              if (!_isDisabled(optionObj)) {
+              if (!optionObj.disabled) {
                 scope.$apply(function () {
                   // triggering select/unselect modifies optionObj
                   ngSelectCtrl[optionObj.selected ? 'unselect' : 'select'](optionObj);
@@ -270,17 +271,24 @@ function NgSelectCtrl($scope) {
               return false;
             });
 
+            if (angular.isDefined(disabledExpr)) {
+              // watch for select-disabled evaluation
+              scope.$watch(function (scope) {
+                return scope.$eval(disabledExpr, _getExprLocals(optionObj));
+              }, _updateDisabled, true);
+            }
+
             if (angular.isDefined(classExpr)) {
               // watch for select-class evaluation
               scope.$watch(function (scope) {
-                return scope.$eval(classExpr, _getStyleExprLocals(optionObj));
+                return scope.$eval(classExpr, _getExprLocals(optionObj));
               }, _updateClass, true);
             }
 
             if (angular.isDefined(styleExpr)) {
               // watch for select-style evaluation
               scope.$watch(function (scope) {
-                return scope.$eval(styleExpr, _getStyleExprLocals(optionObj));
+                return scope.$eval(styleExpr, _getExprLocals(optionObj));
               }, _updateStyle, true);
             }
           }
@@ -297,33 +305,25 @@ function NgSelectCtrl($scope) {
         styleExpr = iAttrs.selectStyle || ctrlConfig.styleExpr;
       }
 
-      function _getBaseExprLocals(optionObj) {
-        var locals = {},
-            capitalize = function (str) {
-              str = str.toLowerCase();
-              return str.charAt(0).toUpperCase() + str.slice(1);
-            };
+      var exprLocalsNames = {},
+          capitalize = function (str) {
+            return str.charAt(0).toUpperCase() + str.slice(1);
+          };
+
+      function _getExprLocals(optionObj) {
+        var locals = {};
+
         angular.forEach(optionObj, function (value, key) {
-          locals['$opt' + capitalize(key)] = value;
+          if (angular.isUndefined(exprLocalsNames[key])) {
+            exprLocalsNames[key] = '$opt' + capitalize(key);
+          }
+          locals[exprLocalsNames[key]] = value;
         });
         return locals;
       }
 
-      function _getStyleExprLocals(optionObj) {
-        var locals = _getBaseExprLocals(optionObj);
-        locals.$optDisabled = _isDisabled(optionObj, locals);
-        return locals;
-      }
-
-      function _isDisabled(optionObj, locals) {
-        if (angular.isUndefined(disabledExpr)) {
-          return false;
-        }
-
-        if (angular.isUndefined(locals)) {
-          locals = _getBaseExprLocals(optionObj);
-        }
-        return scope.$eval(disabledExpr, locals);
+      function _updateDisabled(newValue) {
+        optionObj.disabled = newValue;
       }
 
       function _updateStyle(newStyles, oldStyles) {
@@ -337,32 +337,33 @@ function NgSelectCtrl($scope) {
         }
       }
 
-      function _updateClass(newClass, oldClass) {
-        var map = function (obj, judgeFn) {
-              var list = [];
-              angular.forEach(obj, function (v, k) {
-                var res = judgeFn(v, k);
-                if (res) {
-                  list.push(res);
-                }
-              });
-              return list;
-            },
-            removeClass = function (classVal) {
-              if (angular.isObject(classVal) && !angular.isArray(classVal)) {
-                classVal = map(classVal, function(v, k) { if (v) { return k; } });
+      //UPDATE CLASS
+      var map = function (obj, judgeFn) {
+            var list = [];
+            angular.forEach(obj, function (v, k) {
+              var res = judgeFn(v, k);
+              if (res) {
+                list.push(res);
               }
-              iElm.removeClass(angular.isArray(classVal) ? classVal.join(' ') : classVal);
-            },
-            addClass = function (classVal) {
-              if (angular.isObject(classVal) && !angular.isArray(classVal)) {
-                classVal = map(classVal, function(v, k) { if (v) { return k; } });
-              }
-              if (classVal) {
-                iElm.addClass(angular.isArray(classVal) ? classVal.join(' ') : classVal);
-              }
-            };
+            });
+            return list;
+          },
+          removeClass = function (classVal) {
+            if (angular.isObject(classVal) && !angular.isArray(classVal)) {
+              classVal = map(classVal, function(v, k) { if (v) { return k; } });
+            }
+            iElm.removeClass(angular.isArray(classVal) ? classVal.join(' ') : classVal);
+          },
+          addClass = function (classVal) {
+            if (angular.isObject(classVal) && !angular.isArray(classVal)) {
+              classVal = map(classVal, function(v, k) { if (v) { return k; } });
+            }
+            if (classVal) {
+              iElm.addClass(angular.isArray(classVal) ? classVal.join(' ') : classVal);
+            }
+          };
 
+      function _updateClass(newClass, oldClass) {
         if (oldClass && !angular.equals(newClass, oldClass)) {
           removeClass(oldClass);
         }


### PR DESCRIPTION
That will allow us to use old value in calculation of new value. E.g. `select-disabled="!$optDisabled"`.
- We shouldn't watch for expression changes that wasn't defined at all.
  - ExprLocals should not recalculate their names on each call. Names will be calculated once per ngSelectOption at the most.
- Don't store helper functions like `map`, `addClass`, `removeClass` in frequently called functions. (Ideally it can be moved to separate helper service)
